### PR TITLE
Expose Utils

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,4 +2,7 @@
  * Module dependencies
  */
 
-module.exports = require('./lib/model');
+var modella = module.exports = require('./lib/model');
+
+modella.utils = {};
+modella.utils.clone = require('./lib/clone');


### PR DESCRIPTION
Exposing some internal utilities could be useful for plugins. This saves every plugin from having to use `clone` to write in their own version, thus allowing for smaller code bases with less duplicate code.

What do you think?
