### PR TITLE
Model.all(fn) array.js support

### DIFF
--- a/component.json
+++ b/component.json
@@ -5,7 +5,8 @@
   "description": "simplified models",
   "dependencies": {
     "component/emitter": "*",
-    "visionmedia/superagent": "*"
+    "visionmedia/superagent": "*",
+    "matthewmueller/array": "*"
   },
   "scripts": [
     "index.js",

--- a/lib/static.js
+++ b/lib/static.js
@@ -7,6 +7,12 @@ var clone = require('./utils/clone'),
     type = require('./utils/type'),
     noop = function(){};
 
+try {
+  var array = require('array');
+} catch(e) {
+  var array = require('array.js');
+}
+
 /**
  * Add validation `fn()`.
  *
@@ -133,10 +139,10 @@ exports.all = function() {
     }
 
     for (var i = 0, len = body.length; i < len; ++i) {
-      out.push(new self(body[i]));
+      out.push(body[i]);
     }
 
-    fn(null, out);
+    fn(null, array(out));
   }
 };
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "keywords": ["modella", "models"],
   "author": "matthew mueller <mattmuelle@gmail.com>",
   "dependencies": {
-    "emitter": "component/emitter#1.0.0"
+    "emitter": "component/emitter#1.0.0",
+    "array.js": "*"
   },
   "devDependencies": {
     "mocha": "*",

--- a/test/statics.js
+++ b/test/statics.js
@@ -78,7 +78,17 @@ describe("Model.all", function() {
   it("returns objects from the sync layer", function(done) {
     User.all(function(err, users) {
       expect(users).to.have.length(2);
-      expect(users[0].name()).to.equal('Bob');
+      expect(users[0].name).to.equal('Bob');
+      done();
+    });
+  });
+
+  it("supports array.js", function(done) {
+    User.all(function(err, users) {
+      var names = users.map('name');
+      expect(names).to.have.length(2);
+      expect(names[0]).to.equal('Bob');
+      expect(names[1]).to.equal('Tom');
       done();
     });
   });


### PR DESCRIPTION
Added array.js support to `Model.all`.

Allows for things like:

``` js
User.all(function(err, users) {
  var names = users.map('names');
});
```

Only downside of this approach is that we change the signature (probably breaking things). This change makes `users` an array of JSON objects. Before it was an array of User objects. I think this is fine, because you can just do:

``` js
var user = new User(json);
```

Otherwise, I could possibly add an adapter to array.js to support functions as getters, but even that would overwrite some of modella's existing API (ie. `find`). 
