### PR TITLE
Use commit hash instead of tag number for ramitos/map-series dependency.

### DIFF
--- a/component.json
+++ b/component.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "component/emitter": "1.0.1",
     "ForbesLindesay/is-browser": "2.0.0",
-    "ramitos/map-series": "2abc3823ab03b249911bcf0b3c50a45548a6913e"
+    "ramitos/map-series": "0.0.2"
   },
   "scripts": [
     "index.js",


### PR DESCRIPTION
This fixes `Error: can't find remote for "ramitos/map-series"` because it isn't tagged. Alternatively ramitos should add a "0.2.0" tag to his repo.
