### PR TITLE
Expose a base constructor for instanceof

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -16,8 +16,13 @@ try {
  * Expose `createModel`.
  */
 
-module.exports = createModel;
+exports = module.exports = createModel;
 
+/**
+ * Expose base constructor for `instanceof`.
+ */
+
+exports.Model = function Model () {};
 
 /**
  * Create a new model constructor with the given `name`.
@@ -48,6 +53,8 @@ function createModel(name) {
       }
       return result;
     }
+
+    exports.Model.call(this, attrs);
 
     attrs = (attrs) ? clone(attrs) : {};
     this.attrs = {};
@@ -91,8 +98,9 @@ function createModel(name) {
 
   // Prototype
 
-  Model.prototype = {};
+  Model.prototype = Object.create(exports.Model.prototype);
   Model.prototype.model = Model;
+  Model.prototype.constructor = exports.Model;
   for (var key in proto) { Model.prototype[key] = proto[key]; }
 
   return Model;

--- a/test/model.js
+++ b/test/model.js
@@ -23,6 +23,12 @@ describe('model(name)', function() {
     var Something = model('Something');
     expect(Something).to.be.a('function');
   });
+
+  it('models are instances of Model', function(){
+    var Child = model('Child');
+    var child = new Child();
+    expect(child).to.be.a(model.Model);
+  });
 });
 
 describe('new Model(attrs)', function() {


### PR DESCRIPTION
For #37. It'd be useful to have a public "base class" to unequivocally identify a modella model:

``` js
var model = require('modella')
var Shark = model('Shark')
var s = new Shark()

s instanceof Shark
s instanceof model.Model
```

In this PR the constructor does nothing but lend its name to the proud lineage of all models, but we could move stuff in there if we care about that.
