### PR TITLE
Add config for browserify

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
     "emitter-component": "1.0.1",
     "is-browser": "~2.0.0"
   },
+  "browser": {
+    "emitter": "emitter-component"
+  },
   "devDependencies": {
     "mocha": "*",
     "expect.js": "*",


### PR DESCRIPTION
Modella didn't build with browserify due to confusion over `require('emitter')`. Adding a [browser field](https://github.com/substack/node-browserify#browser-field) tidies this up.
