### PR TITLE
properly detect change and store value in type coercion edge case

### DIFF
--- a/lib/static.js
+++ b/lib/static.js
@@ -92,7 +92,7 @@ exports.attr = function(name, options){
       if(newType == 'object' || newType == 'array') {
         changed = true;
       } else
-        changed = this.attrs[name] != val;
+        changed = this.attrs[name] !== val;
 
       if(changed) {
         this.dirty[name] = val;

--- a/test/proto.js
+++ b/test/proto.js
@@ -161,6 +161,12 @@ describe('Model#set(attrs)', function() {
     user.set({ name : 'matt' });
     expect(user.name()).to.be('ryan');
   });
+
+  it('considers "1" to true a changed value', function () {
+    var user = new User({ name : '1'});
+    user.set({ name : true });
+    expect(user.name()).to.be(true);
+  });
 });
 
 describe('Model#isNew()', function() {


### PR DESCRIPTION
Seems to be an edge case where using `!=` instead of `!==` causes a `.set` to incorrectly believe the value is not changing, retain the old value, and pass validation when it should in fact fail due to type mismatch.